### PR TITLE
Update domoticz_accessory.js

### DIFF
--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -44,6 +44,7 @@ function eDomoticzAccessory(platform, IsScene, status, idx, name, haveDimmer, ma
 	this.onValue = "On";
 	this.offValue = "Off";
 	this.cachedValues = {};
+	this.hwType = hwType;
 
 	// Initialize default values, e.g. to get the "factor"
 	var voidCallback = function() {};
@@ -377,6 +378,19 @@ eDomoticzAccessory.prototype = {
 				var heat = (this.subType == "Zone") ? true : false;
 				var therm = (this.subType == "SetPoint") ? true : false;
 				value = ((heat) || (therm)) ? Helper.oneDP(Helper.cleanFloat(s.SetPoint)) : Helper.oneDP(Helper.cleanFloat(s.Temp));
+			}.bind(this));
+			this.platform.log("Data Received for " + this.name + ": " + value);
+			callback(null, value);
+		}.bind(this));
+	},
+	getTemperatureAlternative: function(callback) {
+		Domoticz.deviceStatus(this, function(json) {
+			var value;
+			var sArray = Helper.sortByKey(json.result, "Name");
+			sArray.map(function(s) {
+				var heat = (this.subType == "Zone") ? true : false;
+				var therm = (this.subType == "SetPoint") ? true : false;
+				value = Helper.oneDP(Helper.cleanFloat(s.Temp));
 			}.bind(this));
 			this.platform.log("Data Received for " + this.name + ": " + value);
 			callback(null, value);
@@ -1251,7 +1265,13 @@ eDomoticzAccessory.prototype = {
 					var HeatingDeviceService = new Service.Thermostat(this.name);
 					HeatingDeviceService.getCharacteristic(Characteristic.CurrentHeatingCoolingState).on('get', this.getState.bind(this));
 					HeatingDeviceService.getCharacteristic(Characteristic.TargetHeatingCoolingState).on('get', this.getState.bind(this));
-					HeatingDeviceService.getCharacteristic(Characteristic.CurrentTemperature).on('get', this.getTemperature.bind(this));
+				        // If this is an HGI80, get the current temperature slightly differently
+				        if(this.hwType==Constants.DeviceTypeHoneywellHGI80) {
+				           HeatingDeviceService.getCharacteristic(Characteristic.CurrentTemperature).on('get', this.getTemperatureAlternative.bind(this));
+				        }
+				        else {
+				           HeatingDeviceService.getCharacteristic(Characteristic.CurrentTemperature).on('get', this.getTemperature.bind(this));
+				        }
 					HeatingDeviceService.getCharacteristic(Characteristic.TargetTemperature).on('get', this.getTemperature.bind(this)).on('set', this.setPoint.bind(this));
 					HeatingDeviceService.getCharacteristic(Characteristic.TargetTemperature).setProps({
 						minValue: 4


### PR DESCRIPTION
Resolves the Honeywell Evohome HGI80 issue whereby only the target temperatures are reported. This fix specifically targets the HGI80 hardware type without affecting other devices.